### PR TITLE
Fix a null pointer dereference bug

### DIFF
--- a/gnu/getopt/Getopt.java
+++ b/gnu/getopt/Getopt.java
@@ -1228,7 +1228,8 @@ getopt()
           optarg  = argv[optind];
         }
 
-      c = checkLongOption();
+      if (long_options != null)
+        c = checkLongOption();
 
       if (longopt_handled)
         return(c);


### PR DESCRIPTION
 This commit fixes a null pointer exception in Getopt.
To reproduce the problem, apply the below diff to GetoptDemo.java, and then run GetoptDemo with a -W command-line argument, such as:  `java GetoptDemo -W foo`.  The result is:

```
Exception in thread "main" java.lang.NullPointerException
    at gnu.getopt.Getopt.checkLongOption(Getopt.java:875)
    at gnu.getopt.Getopt.getopt(Getopt.java:1240)
    at GetoptDemo.main(GetoptDemo.java:30)
```

Even if the programmer has made a mistake in specifying the command-line options or the user has made a mistake in supplying them, Getopt shouldn't throw a NullPointerException.

```
--- /home/mernst/research/types/libraries/java-getopt-mernst/gnu/getopt/GetoptDemo.java 2015-07-07 14:13:40.650241839 -0300
+++ -   2015-07-07 14:16:45.011843200 -0300
@@ -22,6 +22,7 @@
  longopts[0] = new LongOpt("help", LongOpt.NO_ARGUMENT, null, 'h');
  longopts[1] = new LongOpt("outputdir", LongOpt.REQUIRED_ARGUMENT, sb, 'o'); 
  longopts[2] = new LongOpt("maximum", LongOpt.OPTIONAL_ARGUMENT, null, 2);
+ longopts = null;
  // 
  Getopt g = new Getopt("testprog", argv, "-:bc::d:hW;", longopts);
  g.setOpterr(false); // We'll do our own error handling
```
